### PR TITLE
Added missing translation in it.countries.php

### DIFF
--- a/app/config/locales/it.countries.php
+++ b/app/config/locales/it.countries.php
@@ -86,7 +86,7 @@ return [
     'IL' => 'Israele',
     'IT' => 'Italia',
     'JM' => 'Giamaica',
-    'JO' => 'Jordan',
+    'JO' => 'Giordania',
     'JP' => 'Giappone',
     'KZ' => 'Kazakistan',
     'KE' => 'Kenya',


### PR DESCRIPTION
Added missing translation for `Jordan` -> `Giordania` in countries list (it)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Added missing string in italian translation

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes.
